### PR TITLE
add Emerge translation

### DIFF
--- a/pages.pt_BR/linux/emerge.md
+++ b/pages.pt_BR/linux/emerge.md
@@ -1,0 +1,33 @@
+# emerge
+
+> Utilitário de gerenciamento de pacotes do Gentoo Linux.
+> Para comandos equivalentes em outros gerenciadores de pacotes, veja <https://wiki.archlinux.org/title/Pacman/Rosetta>.
+> Mais informações: <https://wiki.gentoo.org/wiki/Portage#emerge>.
+
+- Sincronizar todos os pacotes:
+
+`sudo emerge --sync`
+
+- Atualiza todos os pacotes, incluindo dependências:
+
+`sudo emerge {{[-avuDN|--ask --verbose --update --deep --newuse]}} @world`
+
+- Resume uma atualização falha, pulando o pacote que falhou:
+
+`sudo emerge --resume --skipfirst`
+
+- Instala um novo pacote, com confirmação:
+
+`sudo emerge {{[-av|--ask --verbose]}} {{pacote}}`
+
+- Remove um pacote e suas dependências com confirmação:
+
+`sudo emerge {{[-avc|--ask --verbose --depclean]}} {{pacote}}`
+
+- Remove pacotes órfãos (instalados como dependências mas não são mais requisitados por nenhum pacote):
+
+`sudo emerge {{[-avc|--ask --verbose --depclean]}}`
+
+- Procura na base de dados por uma palavra-chave:
+
+`emerge {{[-S|--searchdesc]}} {{palavra-chave}}`


### PR DESCRIPTION
The emerge command is one of the most important commands in Gentoo Linux, and needed a translation. The command sudo emerge --sync in now deprecated, and should now be used sudo emaint --sync. You can verify this information here: https://wiki.gentoo.org/wiki/Ebuild_repository#Repository_synchronization.  In the translation, I preserved the deprecated command since is still a compatibility command, but it should eventually be updated in the original file. I followed the project style and this is my first open source contribution!

<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [ ] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [ ] The page(s) have at most 8 examples.
- [ ] The page description(s) have links to documentation or a homepage.
- [ ] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [ ] The page(s) follow the [style guide](/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md).
- [ ] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
- **Version of the command being documented (if known):**
